### PR TITLE
Conditional positioning

### DIFF
--- a/MidnightTooltip.lua
+++ b/MidnightTooltip.lua
@@ -198,11 +198,6 @@ local function IsWorldTooltip(tooltip)
         return true
     end
 
-    local success, _, unitToken = pcall(tooltip.GetUnit, tooltip)
-    if success and unitToken and strfind(unitToken, "^nameplate") then
-        return true
-    end
-
     return false
 end
 

--- a/MidnightTooltip.lua
+++ b/MidnightTooltip.lua
@@ -37,6 +37,10 @@ local function RefreshSettingsCache()
     settingsCache.cursorOnlyMode = getSetting("cursorOnlyMode", false)
     settingsCache.hideTooltipsInCombat = getSetting("hideTooltipsInCombat", false)
     settingsCache.enableQualityBorder = getSetting("enableQualityBorder", true)
+    settingsCache.defaultInCombat = getSetting("defaultInCombat", false)
+    settingsCache.defaultInInstances = getSetting("defaultInInstances", false)
+    settingsCache.worldTooltipPositionMode = getSetting("worldTooltipPositionMode", "mouseover")
+    settingsCache.uiTooltipPositionMode = getSetting("uiTooltipPositionMode", "mouseover")
     settingsCache.anchorPoint = getSetting("anchorPoint", "BOTTOM")
     settingsCache.cursorOffsetX = getSetting("cursorOffsetX", 0)
     settingsCache.cursorOffsetY = getSetting("cursorOffsetY", 0)
@@ -164,6 +168,31 @@ end
 -- Helper function to check if tooltip is for a WorldMap element
 local function IsWorldMapTooltip()
     return WorldMapFrame and WorldMapFrame:IsShown()
+end
+
+local function IsWorldTooltipOwner(owner)
+    return owner and owner == WorldFrame
+end
+
+local function ShouldUseDefaultPosition(tooltip)
+    if not settingsCache.enableCursorAnchor then
+        return true
+    end
+
+    if settingsCache.defaultInCombat and InCombatLockdown() then
+        return true
+    end
+
+    if settingsCache.defaultInInstances and isInRestrictedInstance then
+        return true
+    end
+
+    local owner = tooltip:GetOwner()
+    if IsWorldTooltipOwner(owner) then
+        return settingsCache.worldTooltipPositionMode == "default"
+    end
+
+    return settingsCache.uiTooltipPositionMode == "default"
 end
 
 -- Inspect throttling to avoid hitting rate limits
@@ -774,8 +803,8 @@ function MidnightTooltip:OnInitialize()
             end
         end
         
-        -- Position at cursor
-        if settingsCache.enableCursorAnchor then
+        -- Position at cursor when no default-position rule applies
+        if not ShouldUseDefaultPosition(self) then
             local x, y = GetCursorPosition()
             local tooltipScale = (settingsCache.tooltipScale and settingsCache.tooltipScale > 0) and (settingsCache.tooltipScale / 100) or 1
             local anchorPoint = settingsCache.anchorPoint or "BOTTOM"
@@ -865,7 +894,7 @@ function MidnightTooltip:OnInitialize()
         end
         
         -- Reposition tooltip to cursor for smooth tracking (skip for special frames)
-        if not isSpecialFrame and settingsCache.enableCursorAnchor and self:IsShown() then
+        if not isSpecialFrame and self:IsShown() and not ShouldUseDefaultPosition(self) then
             local x, y = GetCursorPosition()
             local tooltipScale = (settingsCache.tooltipScale and settingsCache.tooltipScale > 0) and (settingsCache.tooltipScale / 100) or 1
             local anchorPoint = settingsCache.anchorPoint or "BOTTOM"

--- a/MidnightTooltip.lua
+++ b/MidnightTooltip.lua
@@ -171,7 +171,39 @@ local function IsWorldMapTooltip()
 end
 
 local function IsWorldTooltipOwner(owner)
-    return owner and owner == WorldFrame
+    if not owner then
+        return false
+    end
+
+    if owner == WorldFrame then
+        return true
+    end
+
+    if owner.GetName then
+        local success, ownerName = pcall(owner.GetName, owner)
+        if success and ownerName and strfind(ownerName, "^NamePlate") then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function IsWorldTooltip(tooltip)
+    if not tooltip then
+        return false
+    end
+
+    if IsWorldTooltipOwner(tooltip:GetOwner()) then
+        return true
+    end
+
+    local success, _, unitToken = pcall(tooltip.GetUnit, tooltip)
+    if success and unitToken and strfind(unitToken, "^nameplate") then
+        return true
+    end
+
+    return false
 end
 
 local function ShouldUseDefaultPosition(tooltip)
@@ -187,8 +219,7 @@ local function ShouldUseDefaultPosition(tooltip)
         return true
     end
 
-    local owner = tooltip:GetOwner()
-    if IsWorldTooltipOwner(owner) then
+    if IsWorldTooltip(tooltip) then
         return settingsCache.worldTooltipPositionMode == "default"
     end
 

--- a/MidnightTooltip.lua
+++ b/MidnightTooltip.lua
@@ -342,7 +342,22 @@ end
 
 -- Helper to strip color codes from text
 local function StripColorCodes(text)
-    return gsub(gsub(text, COLOR_CODE_PATTERN, ""), COLOR_RESET_PATTERN, "")
+    if not text then
+        return ""
+    end
+
+    -- Some tooltip names can be secure/secret strings in restricted contexts.
+    -- Running string operations on those values can throw, so guard with pcall.
+    local success, strippedText = pcall(function()
+        local noColorCode = gsub(text, COLOR_CODE_PATTERN, "")
+        return gsub(noColorCode, COLOR_RESET_PATTERN, "")
+    end)
+
+    if success and strippedText then
+        return strippedText
+    end
+
+    return text
 end
 
 -- Helper to get item level color based on value
@@ -418,7 +433,20 @@ local function ColorTooltipBorderByUnit(tooltip)
                         prefix = "|cFFFF0000[DND]|r "
                     end
                 end
-                nameText:SetText(prefix .. StripColorCodes(name))
+                -- Build and set text in pcall so secret string values never hard-error.
+                local setNameSuccess = pcall(function()
+                    local cleanName = StripColorCodes(name)
+                    if prefix ~= "" then
+                        nameText:SetText(prefix .. cleanName)
+                    else
+                        nameText:SetText(cleanName)
+                    end
+                end)
+
+                -- Fallback: preserve original text if secure string manipulation failed.
+                if not setNameSuccess then
+                    pcall(nameText.SetText, nameText, name)
+                end
             end
             if settingsCache.showClassColors then
                 nameText:SetTextColor(color.r, color.g, color.b)

--- a/MidnightTooltip.lua
+++ b/MidnightTooltip.lua
@@ -582,8 +582,19 @@ local function ColorTooltipBorderByUnit(tooltip)
                         if lineText then
                             local text = lineText:GetText()
                             if text then
-                                -- Look for "Item Level: XXX" or localized variants
-                                local ilvl = text:match("Item Level:?%s*(%d+)") or text:match("(%d+)%s*Item Level")
+                                -- Look for "Item Level: XXX" or localized variants.
+                                -- Some tooltip lines can be secret strings; guard string operations.
+                                local directMatchSuccess, ilvl = pcall(string.match, text, "Item Level:?%s*(%d+)")
+                                if not ilvl then
+                                    local reverseMatchSuccess
+                                    reverseMatchSuccess, ilvl = pcall(string.match, text, "(%d+)%s*Item Level")
+                                    if not reverseMatchSuccess then
+                                        ilvl = nil
+                                    end
+                                elseif not directMatchSuccess then
+                                    ilvl = nil
+                                end
+
                                 if ilvl then
                                     avgItemLevel = tonumber(ilvl)
                                     -- Hide the original line since we'll add our own

--- a/MidnightTooltip.lua
+++ b/MidnightTooltip.lua
@@ -495,10 +495,13 @@ local function ColorTooltipBorderByUnit(tooltip)
         for i = 2, numLines do
             local lineText = _G[tooltipName .. "TextLeft" .. i]
             if lineText then
-                local text = lineText:GetText()
-                if text then
+                local textSuccess, text = pcall(lineText.GetText, lineText)
+                if textSuccess and text then
+                    local findSuccess, hasRecharging, hasSec, hasMin, hasCooldown = pcall(function()
+                        return string.find(text, "Recharging", 1, true), string.find(text, "sec", 1, true), string.find(text, "min", 1, true), string.find(text, "ooldown", 1, true)
+                    end)
                     -- Skip lines that might contain cooldown info - combined pattern for efficiency
-                    if not text:find("Recharging") and not text:find("sec") and not text:find("min") and not text:find("ooldown") then
+                    if findSuccess and not hasRecharging and not hasSec and not hasMin and not hasCooldown then
                         local cleanText = StripColorCodes(text)
                         
                         -- Check for guild name
@@ -506,7 +509,14 @@ local function ColorTooltipBorderByUnit(tooltip)
                         if settingsCache.showGuildColors and guildName and i == 2 then
                             -- Guild name is typically on line 2
                             -- It may appear as "GuildName" or "GuildName-RealmName"
-                            if cleanText == guildName or cleanText:match("^" .. guildName:gsub("%-", "%%-") .. "%-") or cleanText:match("^" .. guildName:gsub("%-", "%%-") .. "$") then
+                            local guildPatternSuccess, escapedGuildName = pcall(string.gsub, guildName, "%-", "%%-")
+                            local guildLineSuccess, guildWithRealm, guildExact = pcall(function()
+                                if not guildPatternSuccess or not escapedGuildName then
+                                    return false, false
+                                end
+                                return string.match(cleanText, "^" .. escapedGuildName .. "%-"), string.match(cleanText, "^" .. escapedGuildName .. "$")
+                            end)
+                            if cleanText == guildName or (guildLineSuccess and (guildWithRealm or guildExact)) then
                                 isGuildLine = true
                                 lineText:SetText(cleanText)
                                 if isGuildMate then
@@ -518,9 +528,12 @@ local function ColorTooltipBorderByUnit(tooltip)
                         end
                         
                         if not isGuildLine then
-                            if cleanText:match("Horde") or cleanText:match("Alliance") then
+                            local factionMatchSuccess, hordeMatch, allianceMatch = pcall(function()
+                                return string.match(cleanText, "Horde"), string.match(cleanText, "Alliance")
+                            end)
+                            if factionMatchSuccess and (hordeMatch or allianceMatch) then
                                 if settingsCache.showFaction then
-                                    if cleanText:match("Horde") then
+                                    if hordeMatch then
                                         lineText:SetTextColor(1.0, 0.0, 0.0)
                                     else
                                         lineText:SetTextColor(0.0, 0.44, 0.87)
@@ -528,8 +541,11 @@ local function ColorTooltipBorderByUnit(tooltip)
                                 else
                                     lineText:SetText("")  -- Hide the line
                                 end
-                            elseif settingsCache.showClassColors and not cleanText:match("^Level") then
-                                lineText:SetTextColor(color.r, color.g, color.b)
+                            elseif settingsCache.showClassColors then
+                                local levelMatchSuccess, levelMatch = pcall(string.match, cleanText, "^Level")
+                                if levelMatchSuccess and not levelMatch then
+                                    lineText:SetTextColor(color.r, color.g, color.b)
+                                end
                             end
                         end
                     end

--- a/MidnightTooltip.lua
+++ b/MidnightTooltip.lua
@@ -988,10 +988,11 @@ function MidnightTooltip:OnInitialize()
                 self:SetAlpha(1 - fadeProgress)
             end
         else
-            -- Ensure tooltip is fully opaque when not fading
-            if self:GetAlpha() < 1 then
-                self:SetAlpha(1)
-            end
+            -- Ensure tooltip is fully opaque when not fading.
+            -- NOTE: Avoid comparing the alpha value here; in some restricted tooltip
+            -- update paths Blizzard can hand back a protected/secret numeric value
+            -- that errors when compared (e.g. `self:GetAlpha() < 1`).
+            self:SetAlpha(1)
         end
     end)
     

--- a/MidnightTooltip.toc
+++ b/MidnightTooltip.toc
@@ -1,5 +1,5 @@
 ## MidnightTooltip.toc
-## Interface: 120001
+## Interface: 120001, 120007
 ## Title: MidnightTooltip
 ## Notes: A tooltip enhancement addon for World of Warcraft.
 ## Author: Vanskater

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ MidnightTooltip is a World of Warcraft addon that provides cursor-following tool
 - **Quality border colors** - Colors tooltip borders based on item quality (including upgraded items)
 - **Shopping tooltip positioning** - Intelligently positions comparison tooltips with secret value protection
 - **World map compatibility** - Shopping tooltips work correctly with world quest rewards
+- **Conditional tooltip positions** - Optional default-position overrides for combat, instances, and tooltip source type (WorldFrame vs UI frames)
 
 ### Combat & Instances
 - **Hide tooltips in combat** - Option to hide tooltips during combat in dungeons/raids
@@ -78,6 +79,14 @@ Access the options through the in-game Interface Options menu or by typing `/mtt
 - Hide tooltips in combat during dungeons/raids
 - Enable quality borders
 
+**Conditional tooltip positions (submenu):**
+- Force default Blizzard tooltip position while in combat
+- Force default Blizzard tooltip position in dungeons/raids/scenarios
+- Pick position mode per source:
+  - WorldFrame tooltips (units in the world)
+  - UnitFrame/UI tooltips (action bars, inventory, unit frames)
+- Includes built-in use-case guidance for each mode combination
+
 **Player Information:**
 - Toggle class colorswith custom color pickers for:
   - Your guild members (default: magenta)
@@ -110,6 +119,10 @@ enableCursorAnchor = true
 cursorOnlyMode = false
 hideTooltipsInCombat = false
 enableQualityBorder = true
+defaultInCombat = false
+defaultInInstances = false
+worldTooltipPositionMode = "mouseover"
+uiTooltipPositionMode = "mouseover"
 anchorPoint = "BOTTOM"
 cursorOffsetX = 0
 cursorOffsetY = 0

--- a/config.lua
+++ b/config.lua
@@ -827,9 +827,15 @@ local worldDropdown = CreateFrame("Frame", "MidnightTooltipWorldTooltipModeDropd
 worldDropdown:SetPoint("TOPLEFT", worldLabel, "BOTTOMLEFT", -15, -4)
 UIDropDownMenu_SetWidth(worldDropdown, 220)
 
+local function SetDropdownSelection(dropdown, value)
+    local normalizedValue = NormalizePositionMode(value)
+    UIDropDownMenu_SetSelectedValue(dropdown, normalizedValue)
+    UIDropDownMenu_SetText(dropdown, GetPositionModeText(normalizedValue))
+end
+
 local function WorldDropdown_OnClick(self)
     SetActiveSetting("worldTooltipPositionMode", NormalizePositionMode(self.value))
-    UIDropDownMenu_SetText(worldDropdown, self:GetText())
+    SetDropdownSelection(worldDropdown, self.value)
     CloseDropDownMenus()
     if addon and addon.RefreshSettingsCache then
         addon.RefreshSettingsCache()
@@ -840,6 +846,7 @@ local function WorldDropdown_Initialize(self)
     local info = UIDropDownMenu_CreateInfo()
     local selectedMode = NormalizePositionMode(MidnightTooltipDB.worldTooltipPositionMode)
     for _, mode in ipairs(positionModes) do
+        info = UIDropDownMenu_CreateInfo()
         info.text = mode.text
         info.value = mode.value
         info.func = WorldDropdown_OnClick
@@ -863,7 +870,7 @@ UIDropDownMenu_SetWidth(uiDropdown, 220)
 
 local function UIDropdown_OnClick(self)
     SetActiveSetting("uiTooltipPositionMode", NormalizePositionMode(self.value))
-    UIDropDownMenu_SetText(uiDropdown, self:GetText())
+    SetDropdownSelection(uiDropdown, self.value)
     CloseDropDownMenus()
     if addon and addon.RefreshSettingsCache then
         addon.RefreshSettingsCache()
@@ -874,6 +881,7 @@ local function UIDropdown_Initialize(self)
     local info = UIDropDownMenu_CreateInfo()
     local selectedMode = NormalizePositionMode(MidnightTooltipDB.uiTooltipPositionMode)
     for _, mode in ipairs(positionModes) do
+        info = UIDropDownMenu_CreateInfo()
         info.text = mode.text
         info.value = mode.value
         info.func = UIDropdown_OnClick
@@ -922,14 +930,22 @@ UpdateAnchoringState = function()
     SetDropdownFrameEnabled(uiDropdown, anchoringEnabled)
 end
 
-conditionalPanel:SetScript("OnShow", function()
+local function RefreshConditionalPanelControls()
     SetActiveSetting("worldTooltipPositionMode", NormalizePositionMode(MidnightTooltipDB.worldTooltipPositionMode))
     SetActiveSetting("uiTooltipPositionMode", NormalizePositionMode(MidnightTooltipDB.uiTooltipPositionMode))
     defaultCombatCheckbox:SetChecked(MidnightTooltipDB.defaultInCombat)
     defaultInstancesCheckbox:SetChecked(MidnightTooltipDB.defaultInInstances)
-    UIDropDownMenu_SetText(worldDropdown, GetPositionModeText(MidnightTooltipDB.worldTooltipPositionMode))
-    UIDropDownMenu_SetText(uiDropdown, GetPositionModeText(MidnightTooltipDB.uiTooltipPositionMode))
+    SetDropdownSelection(worldDropdown, MidnightTooltipDB.worldTooltipPositionMode)
+    SetDropdownSelection(uiDropdown, MidnightTooltipDB.uiTooltipPositionMode)
     UpdateAnchoringState()
+end
+
+conditionalPanel:SetScript("OnShow", function()
+    RefreshConditionalPanelControls()
+end)
+
+C_Timer.After(0, function()
+    RefreshConditionalPanelControls()
 end)
 
 -- Create Profiles Panel

--- a/config.lua
+++ b/config.lua
@@ -347,7 +347,7 @@ local otherGuildColorLabel, otherGuildColorSwatch, otherGuildColorTexture = Crea
 )
 
 myGuildColorLabel:ClearAllPoints()
-myGuildColorLabel:SetPoint("TOPLEFT", guildColorsCheckbox, "BOTTOMLEFT", 0, -18)
+myGuildColorLabel:SetPoint("TOPLEFT", guildColorsCheckbox, "BOTTOMLEFT", 0, -42)
 
 -- Right Column - Information Display Options
 -- Show Player Status checkbox (Row 1, Right Column)
@@ -770,6 +770,15 @@ local positionModes = {
     { text = "Default (UI Edit Mode position)", value = "default" },
 }
 
+local function NormalizePositionMode(value)
+    for _, mode in ipairs(positionModes) do
+        if mode.value == value then
+            return mode.value
+        end
+    end
+    return positionModes[1].value
+end
+
 local function GetPositionModeText(value)
     for _, mode in ipairs(positionModes) do
         if mode.value == value then
@@ -802,11 +811,12 @@ end
 
 local function WorldDropdown_Initialize(self)
     local info = UIDropDownMenu_CreateInfo()
+    local selectedMode = NormalizePositionMode(MidnightTooltipDB.worldTooltipPositionMode)
     for _, mode in ipairs(positionModes) do
         info.text = mode.text
         info.value = mode.value
         info.func = WorldDropdown_OnClick
-        info.checked = (MidnightTooltipDB.worldTooltipPositionMode == mode.value)
+        info.checked = (selectedMode == mode.value)
         UIDropDownMenu_AddButton(info)
     end
 end
@@ -835,11 +845,12 @@ end
 
 local function UIDropdown_Initialize(self)
     local info = UIDropDownMenu_CreateInfo()
+    local selectedMode = NormalizePositionMode(MidnightTooltipDB.uiTooltipPositionMode)
     for _, mode in ipairs(positionModes) do
         info.text = mode.text
         info.value = mode.value
         info.func = UIDropdown_OnClick
-        info.checked = (MidnightTooltipDB.uiTooltipPositionMode == mode.value)
+        info.checked = (selectedMode == mode.value)
         UIDropDownMenu_AddButton(info)
     end
 end
@@ -885,10 +896,12 @@ UpdateAnchoringState = function()
 end
 
 conditionalPanel:SetScript("OnShow", function()
+    MidnightTooltipDB.worldTooltipPositionMode = NormalizePositionMode(MidnightTooltipDB.worldTooltipPositionMode)
+    MidnightTooltipDB.uiTooltipPositionMode = NormalizePositionMode(MidnightTooltipDB.uiTooltipPositionMode)
     defaultCombatCheckbox:SetChecked(MidnightTooltipDB.defaultInCombat)
     defaultInstancesCheckbox:SetChecked(MidnightTooltipDB.defaultInInstances)
-    UIDropDownMenu_SetText(worldDropdown, GetPositionModeText(MidnightTooltipDB.worldTooltipPositionMode or "mouseover"))
-    UIDropDownMenu_SetText(uiDropdown, GetPositionModeText(MidnightTooltipDB.uiTooltipPositionMode or "mouseover"))
+    UIDropDownMenu_SetText(worldDropdown, GetPositionModeText(MidnightTooltipDB.worldTooltipPositionMode))
+    UIDropDownMenu_SetText(uiDropdown, GetPositionModeText(MidnightTooltipDB.uiTooltipPositionMode))
     UpdateAnchoringState()
 end)
 

--- a/config.lua
+++ b/config.lua
@@ -46,6 +46,13 @@ local defaults = {
     customOtherGuildColorB = 0.8,
 }
 
+local conditionalProfileKeys = {
+    "defaultInCombat",
+    "defaultInInstances",
+    "worldTooltipPositionMode",
+    "uiTooltipPositionMode",
+}
+
 -- Create saved variables table (these will be properly loaded by TOC after ADDON_LOADED)
 MidnightTooltipDB = MidnightTooltipDB or {}
 MidnightTooltipProfiles = MidnightTooltipProfiles or {}
@@ -69,6 +76,17 @@ local function InitializeSettings()
     MidnightTooltipDB.currentProfile = MidnightTooltipDB.currentProfile or "Default"
     if not MidnightTooltipProfiles[MidnightTooltipDB.currentProfile] then
         MidnightTooltipDB.currentProfile = "Default"
+    end
+
+    local activeProfile = MidnightTooltipProfiles[MidnightTooltipDB.currentProfile]
+    if activeProfile then
+        for _, key in ipairs(conditionalProfileKeys) do
+            if activeProfile[key] ~= nil then
+                MidnightTooltipDB[key] = activeProfile[key]
+            else
+                activeProfile[key] = MidnightTooltipDB[key]
+            end
+        end
     end
 end
 

--- a/config.lua
+++ b/config.lua
@@ -98,6 +98,15 @@ local function ApplyProfileToActiveSettings(profileName)
     return true
 end
 
+local function SetActiveSetting(key, value)
+    MidnightTooltipDB[key] = value
+
+    local currentProfile = MidnightTooltipDB.currentProfile
+    if currentProfile and MidnightTooltipProfiles[currentProfile] then
+        MidnightTooltipProfiles[currentProfile][key] = value
+    end
+end
+
 -- Create event frame to initialize after saved variables are loaded
 local initFrame = CreateFrame("Frame")
 initFrame:RegisterEvent("ADDON_LOADED")
@@ -747,7 +756,7 @@ defaultCombatCheckbox.Text:SetText("Use default tooltip position while in combat
 ConfigureCheckboxText(defaultCombatCheckbox, 560)
 defaultCombatCheckbox.tooltipText = "When enabled, all tooltips use Blizzard's default position during combat."
 defaultCombatCheckbox:SetScript("OnClick", function(self)
-    MidnightTooltipDB.defaultInCombat = self:GetChecked()
+    SetActiveSetting("defaultInCombat", self:GetChecked())
     if addon and addon.RefreshSettingsCache then
         addon.RefreshSettingsCache()
     end
@@ -759,7 +768,7 @@ defaultInstancesCheckbox.Text:SetText("Use default tooltip position in dungeons/
 ConfigureCheckboxText(defaultInstancesCheckbox, 560)
 defaultInstancesCheckbox.tooltipText = "When enabled, all tooltips use Blizzard's default position in dungeons, raids, and scenarios."
 defaultInstancesCheckbox:SetScript("OnClick", function(self)
-    MidnightTooltipDB.defaultInInstances = self:GetChecked()
+    SetActiveSetting("defaultInInstances", self:GetChecked())
     if addon and addon.RefreshSettingsCache then
         addon.RefreshSettingsCache()
     end
@@ -801,7 +810,7 @@ worldDropdown:SetPoint("TOPLEFT", worldLabel, "BOTTOMLEFT", -15, -4)
 UIDropDownMenu_SetWidth(worldDropdown, 220)
 
 local function WorldDropdown_OnClick(self)
-    MidnightTooltipDB.worldTooltipPositionMode = self.value
+    SetActiveSetting("worldTooltipPositionMode", NormalizePositionMode(self.value))
     UIDropDownMenu_SetText(worldDropdown, self:GetText())
     CloseDropDownMenus()
     if addon and addon.RefreshSettingsCache then
@@ -835,7 +844,7 @@ uiDropdown:SetPoint("TOPLEFT", uiLabel, "BOTTOMLEFT", -15, -4)
 UIDropDownMenu_SetWidth(uiDropdown, 220)
 
 local function UIDropdown_OnClick(self)
-    MidnightTooltipDB.uiTooltipPositionMode = self.value
+    SetActiveSetting("uiTooltipPositionMode", NormalizePositionMode(self.value))
     UIDropDownMenu_SetText(uiDropdown, self:GetText())
     CloseDropDownMenus()
     if addon and addon.RefreshSettingsCache then
@@ -896,8 +905,8 @@ UpdateAnchoringState = function()
 end
 
 conditionalPanel:SetScript("OnShow", function()
-    MidnightTooltipDB.worldTooltipPositionMode = NormalizePositionMode(MidnightTooltipDB.worldTooltipPositionMode)
-    MidnightTooltipDB.uiTooltipPositionMode = NormalizePositionMode(MidnightTooltipDB.uiTooltipPositionMode)
+    SetActiveSetting("worldTooltipPositionMode", NormalizePositionMode(MidnightTooltipDB.worldTooltipPositionMode))
+    SetActiveSetting("uiTooltipPositionMode", NormalizePositionMode(MidnightTooltipDB.uiTooltipPositionMode))
     defaultCombatCheckbox:SetChecked(MidnightTooltipDB.defaultInCombat)
     defaultInstancesCheckbox:SetChecked(MidnightTooltipDB.defaultInInstances)
     UIDropDownMenu_SetText(worldDropdown, GetPositionModeText(MidnightTooltipDB.worldTooltipPositionMode))

--- a/config.lua
+++ b/config.lua
@@ -169,7 +169,11 @@ end
 
 local function CreateSectionFrame(parent, anchorTo, width, height)
     local section = CreateFrame("Frame", nil, parent, "BackdropTemplate")
-    section:SetPoint("TOPLEFT", anchorTo)
+    if type(anchorTo) == "table" then
+        section:SetPoint(unpack(anchorTo))
+    else
+        section:SetPoint("TOPLEFT", anchorTo)
+    end
     section:SetSize(width, height)
     section:SetBackdrop({
         bgFile = "Interface\\ChatFrame\\ChatFrameBackground",

--- a/config.lua
+++ b/config.lua
@@ -347,7 +347,7 @@ local otherGuildColorLabel, otherGuildColorSwatch, otherGuildColorTexture = Crea
 )
 
 myGuildColorLabel:ClearAllPoints()
-myGuildColorLabel:SetPoint("TOPLEFT", guildColorsCheckbox, "BOTTOMLEFT", 0, -42)
+myGuildColorLabel:SetPoint("TOPLEFT", guildColorsCheckbox, "BOTTOMLEFT", 0, -60)
 
 -- Right Column - Information Display Options
 -- Show Player Status checkbox (Row 1, Right Column)


### PR DESCRIPTION
Fixes #6 
Adds new conditional positioning (mouseover or default) depending on several use cases: 

1. Combat State
2. Dungeon/Raid
3. World Unit or Frame Unit

Adds relevant options, fixes option formatting and creates a new option pane to govern conditional positioning. 

Fixes a few bugs detected with profile management logic. 

<img width="672" height="589" alt="1" src="https://github.com/user-attachments/assets/a8144c0a-3f6a-462c-a7a8-27a4df81decf" />
<img width="664" height="410" alt="2" src="https://github.com/user-attachments/assets/5d201c4a-94d7-4cf9-8511-9fe83962e755" />